### PR TITLE
Write as a plugin to fix Rails compat

### DIFF
--- a/lib/minitest/focus5.rb
+++ b/lib/minitest/focus5.rb
@@ -7,18 +7,10 @@ class Minitest::Test    # :nodoc:
 
   def self.add_to_filter name
     @@filtered_names << "#{self}##{name}"
-    filter = "/^(#{Regexp.union(@@filtered_names).source})$/"
+  end
 
-    index = ARGV.index("-n")
-
-    if index then
-      warn "NOTE: Found `-n <regexp>` arg. This breaks under Rake::TestTask"
-    end
-
-    index = ARGV.index { |arg| arg =~ /^-n/ }
-    ARGV.delete_at index if index
-
-    ARGV << "-n=#{filter}"
+  def self.filtered_names
+    @@filtered_names
   end
 
   ##

--- a/lib/minitest/focus_plugin.rb
+++ b/lib/minitest/focus_plugin.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Minitest
+  def self.plugin_focus_options(_opts, options)
+    return if Minitest::Test.filtered_names.empty?
+
+    index = ARGV.index { |arg| arg =~ /^-n/ || arg =~ /^--name/ }
+    if index
+      warn 'Ignoring -n / --name, using `focus` filters instead'
+      ARGV.delete_at index
+    end
+
+    options[:filter] = "/^(#{Regexp.union(Minitest::Test.filtered_names).source})$/"
+  end
+end


### PR DESCRIPTION
Since rails/rails#38495 has been merged, `focus` no longer works with Rails. Here's what happens:

*  [`Rails::Command#invoke`](https://github.com/jonathanhefner/rails/blob/fba1064153d8e2f4654df7762a7d3664b93e9fc8/railties/lib/rails/command.rb#L31-L56) wraps _commands_ with a block that has `ensure ARGV.replace(old_argv)`.
* [Rails' test command end up calling `Minitest.autorun`](https://github.com/rails/rails/blob/5df9b4584cd6fb653d169ec9a1671532799bdf95/railties/lib/rails/test_unit/runner.rb#L38-L42) which registers an `at_exit` block that runs the tests.
* `at_exit` runs after the `ensure` block, thus `ARGV` is now replaced with the value it had before the _command_ ran (i.e. before minitest-focus changed it).
* `Minitest.run(ARGV)` doesn't know about `-n` filter added.

Repro app: https://github.com/jbourassa/rails-minitest-focus-repro.
Specific commit outlining repro steps: https://github.com/jbourassa/rails-minitest-focus-repro/commit/b4bb96e9d47680599a4a73c2a5bdda12f9501c1c.

---

Instead of mutating `ARGV` to filter the tests, I changed the code to use a minitest plugin. I believe it is more or less equivalent in terms of behaviour.

Do you see any downside with this approach?