### PR TITLE
Prevent a crash if the gem is installed but never required

### DIFF
--- a/lib/minitest/focus_plugin.rb
+++ b/lib/minitest/focus_plugin.rb
@@ -2,6 +2,7 @@
 
 module Minitest
   def self.plugin_focus_options(_opts, options)
+    return unless Minitest::Test.respond_to? :filtered_names
     return if Minitest::Test.filtered_names.empty?
 
     index = ARGV.index { |arg| arg =~ /^-n/ || arg =~ /^--name/ }


### PR DESCRIPTION
Fixes the following crash that happens when the plugin is autoloaded but `require "minitest/focus"` was never invoked in the particular tests being run.

```
Traceback (most recent call last):
        8: from /opt/lib/ruby/gems/2.6.0/gems/minitest-5.14.1/lib/minitest.rb:68:in `block in autorun'
        7: from /opt/lib/ruby/gems/2.6.0/gems/minitest-5.14.1/lib/minitest.rb:128:in `run'
        6: from /opt/lib/ruby/gems/2.6.0/gems/minitest-5.14.1/lib/minitest.rb:174:in `process_args'
        5: from /opt/lib/ruby/gems/2.6.0/gems/minitest-5.14.1/lib/minitest.rb:174:in `new'
        4: from /opt/lib/ruby/2.6.0/optparse.rb:1089:in `initialize'
        3: from /opt/lib/ruby/gems/2.6.0/gems/minitest-5.14.1/lib/minitest.rb:206:in `block in process_args'
        2: from /opt/lib/ruby/gems/2.6.0/gems/minitest-5.14.1/lib/minitest.rb:206:in `each'
        1: from /opt/lib/ruby/gems/2.6.0/gems/minitest-5.14.1/lib/minitest.rb:208:in `block (2 levels) in process_args'
/opt/lib/ruby/gems/2.6.0/gems/minitest-focus-1.2.0/lib/minitest/focus_plugin.rb:5:in `plugin_focus_options': undefined method `filtered_names' for Minitest::Test:Class (NoMethodError)
```
