### PR TITLE
Add focus for describe blocks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,6 +40,19 @@ Inspired by https://github.com/seattlerb/minitest/issues/213
     describe "MyTest2" do
       focus; it "does something"       do pass end
       focus  it("does something else") {  pass   } # block precedence needs {}
+
+      focus
+      describe "Group" do
+        it "should run this"           do pass end
+        it "will run this too"         do pass end
+        describe "Nesting" do
+          it "even this"               do pass end
+        end
+      end
+
+      focus describe("Group") {
+        it "or even this"              do pass end
+      }
     end
 
 == REQUIREMENTS:

--- a/lib/minitest/focus.rb
+++ b/lib/minitest/focus.rb
@@ -7,8 +7,8 @@ class Minitest::Test    # :nodoc:
 
   @@filtered_names = [] # :nodoc:
 
-  def self.add_to_filter name
-    @@filtered_names << "#{self}##{name}"
+  def self.add_to_filter name, object = self
+    @@filtered_names << "#{object}##{name}"
   end
 
   def self.filtered_names
@@ -16,7 +16,7 @@ class Minitest::Test    # :nodoc:
   end
 
   ##
-  # Focus on the next test defined. Cumulative. Equivalent to
+  # Focus on the next test/describe defined. Cumulative. Equivalent to
   # running with command line arg: -n /test_name|.../
   #
   #   class MyTest < Minitest::Test
@@ -38,7 +38,14 @@ class Minitest::Test    # :nodoc:
   #   end
 
   def self.focus name = nil
-    if name then
+    if name.is_a?(Class)                             # describe inline
+      name.methods_matching(/^test_/).each do |test|
+        add_to_filter test, name
+      end
+      name.children.each do |child|                  # nesting
+        focus child
+      end
+    elsif name
       add_to_filter name
     else
       set_focus_trap
@@ -46,14 +53,26 @@ class Minitest::Test    # :nodoc:
   end
 
   ##
-  # Sets a one-off method_added callback to set focus on the method
-  # defined next.
+  # Sets a one-off method_added callback to set focus on the
+  # method/describe defined next.
 
   def self.set_focus_trap
     meta = class << self; self; end
 
     meta.send :define_method, :method_added do |name|
       add_to_filter name
+
+      meta.send :remove_method, :method_added
+      meta.send :remove_method, :describe
+    end
+
+    meta.send :define_method, :describe do |name, &block|
+      meta.send :remove_method, :describe
+      meta.send :define_method, :method_added do |name|
+        add_to_filter name
+      end
+
+      super name, &block
 
       meta.send :remove_method, :method_added
     end

--- a/test/minitest/test_focus.rb
+++ b/test/minitest/test_focus.rb
@@ -17,3 +17,14 @@ describe "MyTest2" do
          it "bombs"                 do flunk end
   focus; it "has non-word ['chars'" do pass  end # Will raise invalid RegExp unless correctly escaped
 end
+
+describe "MyTest3" do
+         describe("Nope")    {                        it "nope"       do flunk end }
+  focus  describe("Inline")  {                        it "inline"     do pass  end
+                               describe("Inline^2") { it "inline^2"   do pass  end } }
+         describe("Middle")  {                        it "middle"     do flunk end }
+  focus; describe("Next")    {                        it "next"       do pass  end
+                               describe("Next^2")   { it "next^2"     do pass  end } }
+         describe("Trail")   {                        it "trail"      do flunk end }
+  focus; describe("Empty")   {};                      it "post empty" do flunk end
+end


### PR DESCRIPTION
Allow calling focus on/before a describe block to focus on all tests within.

```ruby
describe "My Test" do
  focus
  describe "Group 1" do
    it "will run this" {}  # previous was _just_ this focus
    it "and this"      {}  # now runs this as well
    describe do
      it "this too"    {}  # double nesting also
    end
  end
end
```