### PR TITLE
Load focus plugin if minitest/focus is required (MT6)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,8 +24,6 @@ Inspired by https://github.com/seattlerb/minitest/issues/213
     require "minitest/autorun"
     require "minitest/focus"
 
-    Minitest.load :focus # for MT6+, push up to test_helper as needed
-
     class MyTest < Minitest::Test
       def test_unrelated; ...; end       # will NOT run
 

--- a/lib/minitest/focus.rb
+++ b/lib/minitest/focus.rb
@@ -1,5 +1,7 @@
 require "minitest/test"
 
+Minitest.load(:focus) if Minitest.respond_to? :load # MT6
+
 class Minitest::Test    # :nodoc:
   class Focus           # :nodoc:
     VERSION = "1.4.0"   # :nodoc:

--- a/test/minitest/test_focus.rb
+++ b/test/minitest/test_focus.rb
@@ -1,5 +1,4 @@
 require "minitest/autorun"
-Minitest.load :focus if Minitest.respond_to? :load # MT6
 require "minitest/focus"
 
 class MyTest1 < Minitest::Test


### PR DESCRIPTION
This PR proposes a small change to automatically call `Minitest.load :focus`  on Minitest 6 upon `require "minitest/focus"`.

This simplifies usage and makes upgrading from MT 5 → 6 easier, since users will already have `require "minitest/focus"` in their test helper. Asking users to call both `require` and `Minitest.load` seems redundant.

This simplification is also consistent with how the MT6 version of `minitest-rg` is now implemented: https://github.com/minitest/minitest-rg/blob/9e2568876a3fa3fb65393ba6fd00a093f1246125/lib/minitest/rg.rb#L5